### PR TITLE
Fixed used after free bug in ffi_type_array_create

### DIFF
--- a/libffi-rs/src/middle/types.rs
+++ b/libffi-rs/src/middle/types.rs
@@ -102,6 +102,7 @@ where
     let new = ffi_type_array_create_empty(size);
     for (i, element) in elements.enumerate() {
         *new.add(i) = *element.0;
+        forget(element);
     }
 
     new


### PR DESCRIPTION
In `middle::types::ffi_type_array_create` the `ffi_type` of `element` is copied to `new`, but when `element` is dropped at the end of the loop, the `ffi_type` is deallocated while still readable from `new`.

If we add `forget(element)`, the `ffi_type` won't be deallocated. Since `Type::drop` only deallocates it's `ffi_type`, this should be safe because the `ffi_type` is now owned by the resulting `TypeArray`.
